### PR TITLE
:path-params instead of :params ???

### DIFF
--- a/documentation/service-routing.md
+++ b/documentation/service-routing.md
@@ -251,7 +251,7 @@ prepending ':' to the segment's name:
 
 ```clj
 (defn hello-who [req]
-  (let [who (get-in req [:params :who])]
+  (let [who (get-in req [:path-params :who])]
     (ring.util.response/response (str "Hello " who))))
 
 (defroutes route-table [[["/hello/:who" {:get hello-who}]]])


### PR DESCRIPTION
I think the docs mean to say use :path-params in this case. I'm new to pedestal, but as far as I can tell :params is not available in the request.

See pedestal-dev thread:
https://groups.google.com/forum/#!topic/pedestal-dev/zEM7S6ZwBmg
