### PR TITLE
fix a few typos

### DIFF
--- a/documentation/service-interceptors.md
+++ b/documentation/service-interceptors.md
@@ -131,7 +131,7 @@ with the context and the caught exception. If this interceptor
 rethrows the exception, it will be caught again and provided to the
 next most immediately preceding interceptor. If the interceptor
 returns a context, processing will continue by calling the leave
-functions of preceeding interceptors, as if the last interceptor in
+functions of preceding interceptors, as if the last interceptor in
 the path had been reached.
 
 During execution, an interceptor may revert to the pause state (most
@@ -185,7 +185,7 @@ dispatch requests to.
 
 ## Compatibility with Ring
 
-The Pedestal service infrastucture is designed to be Ring-compatible
+The Pedestal service infrastructure is designed to be Ring-compatible
 to the greatest extent possible. Specifically HTTP requests and
 responses are represented as Ring-style maps, but held in a wrapping
 Pedestal service context map.

--- a/documentation/service-sse.md
+++ b/documentation/service-sse.md
@@ -45,7 +45,7 @@ resulting SSE interceptor processes a request by:
 and
 
 - passing the current interceptor context to the _stream-ready-fn_ function that was
-  passed as an argument to _start-event-stream_ (previosly
+  passed as an argument to _start-event-stream_ (previously
 called _sse-setup_, which is still supported for backward compatibility).
 
 The _stream-ready-fn_ is responsible for using the context or storing it for


### PR DESCRIPTION
Fixed a few typos with [lein-spell](https://github.com/cldwalker/lein-spell). To catch future typos you'll want this local whitelist in .lein-spell:

```
defroutes
domina
helloworld
marg
defafter
defaround
defbefore
defhandler
defmiddleware
defon
```
