### PR TITLE
REPL usage tips should be value-driven, not stateful

### DIFF
--- a/content/guides/developing-at-the-repl.adoc
+++ b/content/guides/developing-at-the-repl.adoc
@@ -245,7 +245,7 @@ This call produces the following output:
 
 [source,clojure]
 ----
- [:get / :repl.service/home-page]
+ [:get / :pedrepl.service/home-page]
  --------------------------------
  :io.pedestal.http.body-params/body-params (:enter)
  :io.pedestal.http/html-body (:leave)
@@ -309,7 +309,7 @@ With this function in place, we can test for route recognition from the REPL:
 
 [source,clojure]
 ----
-repl.server> (recognize-route :get "/about")
+pedrepl.server> (recognize-route :get "/about")
 
 =>
 {:path "/about",
@@ -326,7 +326,7 @@ repl.server> (recognize-route :get "/about")
    :leave #function[io.pedestal.interceptor.helpers/on-response/fn--8311],
    :error nil}
   {:name nil, :enter #function[io.pedestal.interceptor/eval155/fn--156/fn--157], :leave nil, :error nil}],
- :route-name :repl.service/about-page,
+ :route-name :pedrepl.service/about-page,
  :path-params {},
  :io.pedestal.http.route.prefix-tree/satisfies-constraints? #function[clojure.core/constantly/fn--4614]}
 ----
@@ -355,11 +355,11 @@ Let's generate the URL for the about page:
 
 [source,clojure]
 ----
-repl.server> (dev-url-for ::service/about-page)
+pedrepl.server> (dev-url-for ::service/about-page)
 
 => "/about"
 
-repl.server> (dev-url-for ::service/about-page :absolute? true)
+pedrepl.server> (dev-url-for ::service/about-page :absolute? true)
 
 => "http://localhost:8080/about"
 ----

--- a/content/guides/developing-at-the-repl.adoc
+++ b/content/guides/developing-at-the-repl.adoc
@@ -22,9 +22,11 @@ link:unit-testing[Unit Testing Your Pedestal API] guide.
 After reading this guide, you will be able to perform the following tasks at the REPL:
 
 - Start and stop the HTTP server.
+- Reload your routes without restarting the server.
 - List your application's routes.
 - Find a route by name.
 
+- Test the response of a single route.
 - Test for route recognition.
 - Test url generation.
 - Invoke an interceptor or handler. [TODO]
@@ -46,7 +48,7 @@ https://lambdaisland.com/guides/clojure-repls[Ultimate Guide to Clojure REPLs].
 == Getting Help if You're Stuck
 
 We'll take this in small steps. If you get stuck at any point in this
-guide, please submit an https://github.com/pedestal/docs/issues[issue]
+guide, please submit an https://github.com/pedestal/pedestal-docs/issues[issue]
 about this guide or hop over to the
 https://groups.google.com/forum/#!forum/pedestal-users[mailing list]
 and raise your hand there. You can also try the #pedestal channel in
@@ -62,12 +64,11 @@ following command:
 
 [source,bash]
 ----
-lein new pedestal-service repl; cd repl
+lein new pedestal-service pedrepl; cd pedrepl
 ----
 
 The default project template creates two files: server.clj and
-service.clj. We'll mainly be working with the former to add
-some utility functions that streamline the development workflow.
+service.clj.
 We're now ready to begin exploring the Pedestal application.
 Ladies and gentlemen, start your REPLs!
 
@@ -75,96 +76,37 @@ Ladies and gentlemen, start your REPLs!
 
 The first thing we'll want to do from the REPL is to control
 the HTTP server. By default, your REPL should start in the
-repl.server namespace. The Leiningen template generates
-a useful function namd `run-dev` which will configure and
+pedrepl.server namespace. The Leiningen template generates
+a useful function named `run-dev` which will configure and
 start the HTTP server in development mode, preventing the
 HTTP server thread from being joined and locking up your REPL.
+
+In development mode, routes are reloaded when the service.clj is re-required.
 
 At the REPL, invoke the `run-dev` function to start the
 server:
 
 [source,clojure]
 ----
-repl.server> (run-dev)
+pedrepl.server> (def serv (run-dev))
 ----
 
 Now fire up a browser and navigate to http://localhost:8080
 to see the default, "Hello, World!" message.
 
-To stop the server, try the following invocation:
+Within service.clj, update the home-page handler to respond with "Hello Pedestal User".
+Re-require/reload the service.clj, and when you reload http://localhost:8080
+you'll see the change immediately.
+
+In dev-mode, you should never have to restart the server - changes are picked up
+as soon as they're required/reloaded.
+
+Should you ever need to stop the server, you can do so with the following invocation:
 
 [source,clojure]
 ----
-repl.server> (server/stop *1)
+pedrepl.server> (server/stop serv)
 ----
-
-This works as expected, but can quickly become inconvenient.
-This is because we need to manually keep track of the service
-map that is returned from these functions. The reason for this
-being that the service map includes a reference to a stateful
-object representing the HTTP server. Fortunately, a couple of
-small changes will free us from the tedium of managing state
-by hand. The first thing we'll do is to rename the `run-dev`
-function to `dev-server` and add three new definitions:
-`start`, `stop`, and a replacement for `run-dev`.
-
-[source,clojure]
-----
-(defn dev-server
-  "Configures, starts and returns a development-mode Pedestal server."
-  [& args]
-  (println "\nCreating your [DEV] server...")
-  (-> service/service ;; start with production configuration
-      (merge {:env :dev
-              ;; do not block thread that starts web server
-              ::server/join? false
-              ;; Routes can be a function that resolve routes,
-              ;;  we can use this to set the routes to be reloadable
-              ::server/routes #(route/expand-routes (deref #'service/routes))
-              ;; all origins are allowed in dev mode
-              ::server/allowed-origins {:creds true :allowed-origins (constantly true)}})
-      ;; Wire up interceptor chains
-      server/default-interceptors
-      server/dev-interceptors
-      server/create-server
-      server/start))
-
-(defn start
-  "Starts the Pedestal server."
-  []
-  (alter-var-root #'runnable-service server/start))
-
-(defn stop
-  "Stops the Pedestal server."
-  []
-  (alter-var-root #'runnable-service server/stop))
-
-(defn run-dev
-  "The entry-point for `lein run-dev'."
-  []
-  (alter-var-root #'runnable-service dev-server))
-----
-
-Now, let's restart the REPL and try out our new utilities.
-The first function you'll invoke should be `run-dev`.
-
-[source,clojure]
-----
-repl.server> (run-dev)
-----
-
-Verify once again that the HTTP server responds to requests
-on port 8080. Now, let's stop the server:
-
-[source,clojure]
-----
-repl.server> (stop)
-----
-
-This is much more convenient since we no longer have to keep
-track of our service reference. Try starting and stopping the
-server. You may also want to write a `restart` function that
-invokes `stop` and `start` in succession.
 
 == Working with Routes
 
@@ -182,12 +124,12 @@ declaration should now look like this:
 
 [source,clojure]
 ----
-(ns repl.server
-  (:gen-class) 
+(ns pedrepl.server
+  (:gen-class)
   (:require [io.pedestal.http :as server]
             [io.pedestal.http.route :as route]
-            [io.pedestal.http.route.definition.table :refer [table-routes]] ; <-- new 
-            [repl.service :as service]
+            [io.pedestal.http.route.definition.table :refer [table-routes]] ; <-- new
+            [pedrepl.service :as service]
             [clojure.java.io :as io]))
 ----
 
@@ -206,10 +148,10 @@ Try this new function out at the REPL:
 
 [source,clojure]
 ----
-repl.server> (print-routes)
+pedrepl.server> (print-routes)
 
-[:get /about :repl.service/about-page]
-[:get / :repl.service/home-page]
+[:get /about :pedrepl.service/about-page]
+[:get / :pedrepl.service/home-page]
 nil
 ----
 
@@ -234,7 +176,7 @@ Let's test our new function:
 
 [source,clojure]
 ----
-repl.server> (named-route ::service/home-page)
+pedrepl.server> (named-route ::service/home-page)
 ----
 
 This function returns a map describing the home page
@@ -244,15 +186,20 @@ the list of `:interceptors` that will be invoked when
 this route is requested. It's not uncommon for Pedestal
 services to have quite a few interceptors, so the raw
 output from named-route can get a little unweildy. Let's
-see if we can produce some friendlier output. 
+see if we can produce some friendlier output.
 
 == Interceptors and Handlers
 
 Interceptors are central to Pedestal applications.
 Not only do they provide the same pre- and post-processing
 of requests that Ring middleware does, but they also provide
-the main functionality behind every request. Handlers are
-nothing more than interceptors. It is often 
+the main functionality behind every request.
+Everything in Pedestal is an interceptor, created by a single protocol - IntoInterceptor.
+When a route is compiled in Pedestal, it's compiled with the full list of interceptors
+that run for that endpoint.  It is often useful to see all interceptors
+that get run for a single endpoint.  You can do that by looking through the
+route description or programmatically at the repl.
+Below is one way you might inspect and format that information.
 
 [source,clojure]
 ----
@@ -262,15 +209,15 @@ nothing more than interceptors. It is often
   (letfn [(joined-by
             [s coll]
             (apply str (interpose s coll)))
-          
+
           (repeat-str
             [s n]
             (apply str (repeat n s)))
-          
+
           (interceptor-info
             [i]
             (let [iname  (or (:name i) "<handler>")
-                  stages (joined-by 
+                  stages (joined-by
                           ","
                           (keys
                            (filter
@@ -291,7 +238,7 @@ information.
 
 [source,clojure]
 ----
-repl.server> (print-route ::service/home-page)
+pedrepl.server> (print-route ::service/home-page)
 ----
 
 This call produces the following output:
@@ -308,6 +255,32 @@ This call produces the following output:
 Of course, this is a completely arbitrary representation of your route
 definition. Your own needs and aesthetic sensibilities should inform
 the structure of your application's output.
+
+== Testing Route Responses
+
+It's not even necessary to start a server to see responses of your Pedestal service.
+
+Pedestal ships with a `response-for` function that will return the response of an
+endpoint, exactly how it's passed to the Servlet/Chain-Provider.
+
+Let's jump into the REPL:
+
+[source,clojure]
+----
+pedrepl.server> (require '[io.pedestal.test :refer [response-for]])
+nil
+pedrepl.server> (def tempserv (::server/service-fn (server/create-servlet service/service)))
+pedrepl.server> (response-for tempserv :get "/")
+----
+
+You can also use the same response-for function to test against a live server.
+Assuming you still have a running server from above (e.g. `(def serv (run-dev))`),
+You can do the following:
+
+[source,clojure]
+----
+pedrepl.server> (response-for (::server/service-fn serv) :get "/")
+----
 
 == Route Recognition and Generation
 
@@ -338,7 +311,7 @@ With this function in place, we can test for route recognition from the REPL:
 ----
 repl.server> (recognize-route :get "/about")
 
-=> 
+=>
 {:path "/about",
  :method :get,
  :path-re #"/\Qabout\E",
@@ -369,7 +342,7 @@ the following utility:
 
 [source,clojure]
 ----
-(defn url-for
+(defn dev-url-for
   "Returns a url string for the named route"
   [route-name & opts]
   (let [f (route/url-for-routes (table-routes service/routes))
@@ -382,18 +355,18 @@ Let's generate the URL for the about page:
 
 [source,clojure]
 ----
-repl.server> (url-for ::service/about-page)
+repl.server> (dev-url-for ::service/about-page)
 
 => "/about"
 
-repl.server> (url-for ::service/about-page :absolute? true)
+repl.server> (dev-url-for ::service/about-page :absolute? true)
 
 => "http://localhost:8080/about"
 ----
 
 The `url-for` function accepts a number of useful options. See the
 http://pedestal.io/api/pedestal.route/io.pedestal.http.route.html#var-url-for-routes[API
-documentation] for full details. 
+documentation] for full details.
 
 == Useful Techniques
 


### PR DESCRIPTION
This PR updates the fantastic work done by @christianromney on REPL-driven development with Pedestal.  It removes the stateful `alter-var-root` usage to use the value-oriented API usage.  It also promotes the use of `response-for` at the repl with and without running services.

It discusses that code and routes are reloaded as soon as they're re-required with the dev service.