### PR TITLE
Update hello-world-content-types.adoc

### DIFF
--- a/content/guides/hello-world-content-types.adoc
+++ b/content/guides/hello-world-content-types.adoc
@@ -215,7 +215,7 @@ return in the response body. This table shows the type mapping:
 
 .Content Type Mapping
 |===
-| Object in ;body                        | Content Type
+| Object in :body                        | Content Type
 
 | Byte array                             | application/octet-stream
 | String                                 | text/plain


### PR DESCRIPTION
Fix a typo in the content type mapping table header.