### PR TITLE
Fix typo

### DIFF
--- a/content/guides/hello-world.adoc
+++ b/content/guides/hello-world.adoc
@@ -146,7 +146,7 @@ include::hello/src/hello.clj[tags=ns]
 ----
 <1> This namespace is called 'hello'. This almost always matches the filename.
 <2> We need to use the 'io.pedestal.http' namespace, but would like to only type 'http' later in the file.
-<3> We need to use the 'io.pedestal.http.route.definition' namespace, but would like to spell it as 'routes' later in the file.
+<3> We need to use the 'io.pedestal.http.route.definition' namespace, but would like to spell it as 'route' later in the file.
 
 This is very similar to using "import" in Java or "require" in
 Ruby. It just makes some names from other namespaces available to us


### PR DESCRIPTION
Kinda misleading typo cause `route` here [is used later](https://github.com/pedestal/pedestal-docs/blob/master/content/guides/hello/src/hello.clj#L15) on the creation of a var called `routes`.