### PR TITLE
Fix typo in Service Map Reference

### DIFF
--- a/content/reference/service-map.adoc
+++ b/content/reference/service-map.adoc
@@ -23,7 +23,7 @@ not call `create-server`, but instead assemble a service function,
 chain provider, etc. directly. See the chain provider link:../samples/index[sample].
 
 Pedestal may add other keys to this map for its own use. Other applications
-should treay any such keys and their values as implementation values details
+should treat any such keys and their values as implementation values details
 and their behaviour will remain unspecified.
 
 [cols="s,d,d,d", options="header", grid="rows"]


### PR DESCRIPTION
Fix typo in Service Map Reference