### PR TITLE
Add correct route for URL Query Parameter

### DIFF
--- a/content/guides/hello-world-query-parameters.adoc
+++ b/content/guides/hello-world-query-parameters.adoc
@@ -85,7 +85,7 @@ using them on other request types.
 
 .URL with Query Parameter
 ====
-http://localhost:8890/hello?name=Michael
+http://localhost:8890/greet?name=Michael
 ====
 
 Because query parameters are so common, Pedestal handles them


### PR DESCRIPTION
In the `URL with Query Parameter` example, the route should be '/greet' rather than '/hello'