### PR TITLE
Add server-sent event guide

### DIFF
--- a/content/guides/server-sent-events.adoc
+++ b/content/guides/server-sent-events.adoc
@@ -1,6 +1,6 @@
 = Server Sent Events
-TBD
-2099-01-01
+Larry Christensen
+2018-04-15
 :jbake-type: page
 :toc: macro
 :icons: font
@@ -10,26 +10,164 @@ toc::[]
 
 _by {author}_, _{revdate}_
 
-== Placeholder
-
-**Pull requests welcome!**
-
 == Welcome
+
+Server-sent events make it easy to stream events to a client application. They are appropriate when you only need a unidirection flow of events from the server to the client (if you need a bidirectional connection then Websockets are a better choice).
 
 == What You Will Learn
 
+After reading this guide, you will be able to:
+
+- Configure Pedestal to accept server-sent event connections.
+- Send events on the connection using core.async.
+- Connect to the event stream with a JavaScript client.
+
 == Guide Assumptions
+
+This guide is for intermediate users who have worked through some
+sample applications or the first few link:hello-world[Hello World]
+guides. In particular, you should know how to run a build, start a
+REPL, and start and stop your server.
+
+You do not need to know any other Clojure web frameworks, but if you
+do, you may find some of the comparisons useful. If not, that's OK,
+just skip those sections.
 
 == Getting Help if You're Stuck
 
+If you get stuck at any point in this guide, please submit an
+https://github.com/pedestal/docs/issues[issue] about this guide or hop
+over to the
+https://groups.google.com/forum/#!forum/pedestal-users[mailing list]
+and raise your hand there. You can often find help in the "pedestal"
+channel of the https://clojurians.slack.com[Clojurians Slack team.]
+
 == Where We Are Going
+
+We'll be creating a new Pedestal service project, adding a simple route to stream a counter using server-sent events, and add a simple HTML page that uses a JavaScript EventSource to open a connection to the stream.
 
 == Before We Begin
 
-== Content Section 1
+This guide will use http://leiningen.org/[Leiningen] to generate and
+build a template project. If you haven't already installed it, please
+take a few minutes to set it up.
 
-== Content Section 2
+== Generate Our New Project
 
-== The Path So Far
+----
+$ lein new pedestal-service myapp
+Generating a pedestal-service application called server-sent-events.
+$ cd server-sent-events
+----
 
-== Where To Next?
+== Add Hiccup
+
+We will be using Hiccup to generate our index page, so we will need to add the dependency in our project.clj.
+
+[source,clojure]
+.project.clj
+----
+include::server-sent-events/project.clj[tags=add-hiccup]
+----
+
+== Clean Up
+
+Here's the service.clj file generated for us:
+
+[source,clojure]
+.src/server_sent_events/service.clj
+----
+include::server-sent-events/src/server_sent_events/service.clj[tags=original-service]
+----
+
+Let's simply things by uncommenting the 'Terse/Vector-based routes' section and removing uneccessary code.
+
+[source,clojure]
+.src/server_sent_events/service.clj
+----
+include::server-sent-events/src/server_sent_events/service.clj[tags=cleaned-up]
+----
+
+== Server-Sent Event Route
+
+Now let's add our server-sent event route. First Lets require SSE and core.async.
+
+[source,clojure]
+.src/server_sent_events/service.clj
+----
+include::server-sent-events/src/server_sent_events/service.clj[tags=require-sse]
+----
+
+Now we'll add our counter route. We create the "/counter" route by calling sse/start-event-stream and passing in our stream-ready handler. This creates an interceptor that will handle setting up the connection and call the stream-ready handler. A stream-ready handler receives a core.async event-chan and SSE context as parameters. You send events on the channel using regular core.async (such as async/>!!) functions and terminate the connection by calling async/close! on the channel. Here our event consists the :name and :data keys, but could also contain an :id for the event.
+
+[source,clojure]
+.src/server_sent_events/service.clj
+----
+include::server-sent-events/src/server_sent_events/service.clj[tags=counter-route]
+----
+
+Now lets start up our server.
+
+----
+$ lein run
+...
+Creating your server...
+...
+INFO  org.eclipse.jetty.server.Server - Started @4434ms
+----
+
+And checkout out our event stream in another terminal using curl.
+
+----
+$ curl http://localhost:8080/counter
+event: counter
+data: 0
+
+event: counter
+data: 1
+
+event: counter
+data: 2
+
+event: counter
+data: 3
+
+event: counter
+data: 4
+
+event: counter
+data: 5
+
+event: counter
+data: 6
+
+event: counter
+data: 7
+
+event: counter
+data: 8
+
+event: counter
+data: 9
+
+----
+
+Now lets stop our server (CTRL-C) and update our index route to return an HTML page that connects to our counter route. Since we are adding inline JS we will need to also update our service config to not include secure headers (which include 'unsafe-inline' by default).
+
+[source,clojure]
+.src/server_sent_events/service.clj
+----
+include::server-sent-events/src/server_sent_events/service.clj[tags=html-home]
+----
+
+Now we should be able to restart our server and navigate to http://localhost:8080 and see our counter count up.
+
+== Wrapping Up
+
+This guide covered server-sent event configuration and usage, showing how simple it is to set up a server-sent event route and use it from JavaScript.
+
+This guide was based on the examples in the 
+link:https://github.com/pedestal/samples/tree/master/server-sent-events[server-sent-event sample project]
+and the
+link:../reference/server-sent-events[Server-Send Events Reference,]
+see those for further reference.

--- a/content/guides/server-sent-events/.gitignore
+++ b/content/guides/server-sent-events/.gitignore
@@ -1,0 +1,38 @@
+# Project related
+
+# Java related
+pom.xml
+pom.xml.asc
+*jar
+*.class
+
+# Leiningen
+classes/
+lib/
+native/
+checkouts/
+target/
+.lein-*
+repl-port
+.nrepl-port
+.repl
+
+# Temp Files
+*.orig
+*~
+.*.swp
+.*.swo
+*.tmp
+*.bak
+
+# OS X
+.DS_Store
+
+# Logging
+*.log
+/logs/
+
+# Builds
+out/
+build/
+

--- a/content/guides/server-sent-events/Capstanfile
+++ b/content/guides/server-sent-events/Capstanfile
@@ -1,0 +1,29 @@
+
+#
+# Name of the base image. Capstan will download this automatically from
+# Cloudius S3 repository.
+#
+#base: cloudius/osv
+base: cloudius/osv-openjdk8
+
+#
+# The command line passed to OSv to start up the application.
+#
+#cmdline: /java.so -cp /server-sent-events/app.jar clojure.main -m server-sent-events
+cmdline: /java.so -jar /server-sent-events/app.jar
+
+#
+# The command to use to build the application.
+# You can use any build tool/command (make/rake/lein/boot) - this runs locally on your machine
+#
+# For Leiningen, you can use:
+#build: lein uberjar
+# For Boot, you can use:
+#build: boot build
+
+#
+# List of files that are included in the generated image.
+#
+files:
+  /server-sent-events/app.jar: ./target/server-sent-events-0.0.1-SNAPSHOT-standalone.jar
+

--- a/content/guides/server-sent-events/Dockerfile
+++ b/content/guides/server-sent-events/Dockerfile
@@ -1,0 +1,8 @@
+FROM java:8-alpine
+MAINTAINER Your Name <you@example.com>
+
+ADD target/server-sent-events-0.0.1-SNAPSHOT-standalone.jar /server-sent-events/app.jar
+
+EXPOSE 8080
+
+CMD ["java", "-jar", "/server-sent-events/app.jar"]

--- a/content/guides/server-sent-events/README.md
+++ b/content/guides/server-sent-events/README.md
@@ -1,0 +1,45 @@
+# server-sent-events
+
+FIXME
+
+## Getting Started
+
+1. Start the application: `lein run`
+2. Go to [localhost:8080](http://localhost:8080/) to see: `Hello World!`
+3. Read your app's source code at src/server_sent_events/service.clj. Explore the docs of functions
+   that define routes and responses.
+4. Run your app's tests with `lein test`. Read the tests at test/server_sent_events/service_test.clj.
+5. Learn more! See the [Links section below](#links).
+
+
+## Configuration
+
+To configure logging see config/logback.xml. By default, the app logs to stdout and logs/.
+To learn more about configuring Logback, read its [documentation](http://logback.qos.ch/documentation.html).
+
+
+## Developing your service
+
+1. Start a new REPL: `lein repl`
+2. Start your service in dev-mode: `(def dev-serv (run-dev))`
+3. Connect your editor to the running REPL session.
+   Re-evaluated code will be seen immediately in the service.
+
+### [Docker](https://www.docker.com/) container support
+
+1. Build an uberjar of your service: `lein uberjar`
+2. Build a Docker image: `sudo docker build -t server-sent-events .`
+3. Run your Docker image: `docker run -p 8080:8080 server-sent-events`
+
+### [OSv](http://osv.io/) unikernel support with [Capstan](http://osv.io/capstan/)
+
+1. Build and run your image: `capstan run -f "8080:8080"`
+
+Once the image it built, it's cached.  To delete the image and build a new one:
+
+1. `capstan rmi server-sent-events; capstan build`
+
+
+## Links
+* [Other examples](https://github.com/pedestal/samples)
+

--- a/content/guides/server-sent-events/config/logback.xml
+++ b/content/guides/server-sent-events/config/logback.xml
@@ -1,0 +1,52 @@
+<!-- Logback configuration. See http://logback.qos.ch/manual/index.html -->
+<!-- Scanning is currently turned on; This will impact performance! -->
+<configuration scan="true" scanPeriod="10 seconds">
+  <!-- Silence Logback's own status messages about config parsing
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" /> -->
+
+  <!-- Simple file output -->
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <!-- rollover daily -->
+      <fileNamePattern>logs/server-sent-events-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+      <!-- or whenever the file size reaches 64 MB -->
+      <maxFileSize>64 MB</maxFileSize>
+    </rollingPolicy>
+
+    <!-- Safely log to the same file from multiple JVMs. Degrades performance! -->
+    <prudent>true</prudent>
+  </appender>
+
+
+  <!-- Console output -->
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoder defaults to ch.qos.logback.classic.encoder.PatternLayoutEncoder -->
+    <encoder>
+      <pattern>%-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+    <!-- Only log level INFO and above -->
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>INFO</level>
+    </filter>
+  </appender>
+
+
+  <!-- Enable FILE and STDOUT appenders for all log messages.
+       By default, only log at level INFO and above. -->
+  <root level="INFO">
+    <appender-ref ref="FILE" />
+    <appender-ref ref="STDOUT" />
+  </root>
+
+  <!-- For loggers in the these namespaces, log at all levels. -->
+  <logger name="user" level="ALL" />
+  <!-- To log pedestal internals, enable this and change ThresholdFilter to DEBUG
+    <logger name="io.pedestal" level="ALL" />
+  -->
+
+</configuration>

--- a/content/guides/server-sent-events/project.clj
+++ b/content/guides/server-sent-events/project.clj
@@ -1,0 +1,32 @@
+(defproject server-sent-events "0.0.1-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  ;; tag::add-hiccup[]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [io.pedestal/pedestal.service "0.5.3"]
+
+                 ;; Remove this line and uncomment one of the next lines to
+                 ;; use Immutant or Tomcat instead of Jetty:
+                 [io.pedestal/pedestal.jetty "0.5.3"]
+                 ;; [io.pedestal/pedestal.immutant "0.5.3"]
+                 ;; [io.pedestal/pedestal.tomcat "0.5.3"]
+
+                 [ch.qos.logback/logback-classic "1.1.8" :exclusions [org.slf4j/slf4j-api]]
+                 
+                 [org.slf4j/jul-to-slf4j "1.7.22"]
+                 [org.slf4j/jcl-over-slf4j "1.7.22"]
+                 [org.slf4j/log4j-over-slf4j "1.7.22"]
+                 ;; Add hiccup dependency
+                 [hiccup "1.0.5"]]
+  ;; end::add-hiccup[]
+  :min-lein-version "2.0.0"
+  :resource-paths ["config", "resources"]
+  ;; If you use HTTP/2 or ALPN, use the java-agent to pull in the correct alpn-boot dependency
+  ;:java-agents [[org.mortbay.jetty.alpn/jetty-alpn-agent "2.0.5"]]
+  :profiles {:dev {:aliases {"run-dev" ["trampoline" "run" "-m" "server-sent-events.server/run-dev"]}
+                   :dependencies [[io.pedestal/pedestal.service-tools "0.5.3"]]}
+             :uberjar {:aot [server-sent-events.server]}}
+  :main ^{:skip-aot true} server-sent-events.server)
+

--- a/content/guides/server-sent-events/src/server_sent_events/server.clj
+++ b/content/guides/server-sent-events/src/server_sent_events/server.clj
@@ -1,0 +1,56 @@
+(ns server-sent-events.server
+  (:gen-class) ; for -main method in uberjar
+  (:require [io.pedestal.http :as server]
+            [io.pedestal.http.route :as route]
+            [server-sent-events.service :as service]))
+
+;; This is an adapted service map, that can be started and stopped
+;; From the REPL you can call server/start and server/stop on this service
+(defonce runnable-service (server/create-server service/service))
+
+(defn run-dev
+  "The entry-point for 'lein run-dev'"
+  [& args]
+  (println "\nCreating your [DEV] server...")
+  (-> service/service ;; start with production configuration
+      (merge {:env :dev
+              ;; do not block thread that starts web server
+              ::server/join? false
+              ;; Routes can be a function that resolve routes,
+              ;;  we can use this to set the routes to be reloadable
+              ::server/routes #(route/expand-routes (deref #'service/routes))
+              ;; all origins are allowed in dev mode
+              ::server/allowed-origins {:creds true :allowed-origins (constantly true)}
+              ;; Content Security Policy (CSP) is mostly turned off in dev mode
+              ::server/secure-headers {:content-security-policy-settings {:object-src "none"}}})
+      ;; Wire up interceptor chains
+      server/default-interceptors
+      server/dev-interceptors
+      server/create-server
+      server/start))
+
+(defn -main
+  "The entry-point for 'lein run'"
+  [& args]
+  (println "\nCreating your server...")
+  (server/start runnable-service))
+
+;; If you package the service up as a WAR,
+;; some form of the following function sections is required (for io.pedestal.servlet.ClojureVarServlet).
+
+;;(defonce servlet  (atom nil))
+;;
+;;(defn servlet-init
+;;  [_ config]
+;;  ;; Initialize your app here.
+;;  (reset! servlet  (server/servlet-init service/service nil)))
+;;
+;;(defn servlet-service
+;;  [_ request response]
+;;  (server/servlet-service @servlet request response))
+;;
+;;(defn servlet-destroy
+;;  [_]
+;;  (server/servlet-destroy @servlet)
+;;  (reset! servlet nil))
+

--- a/content/guides/server-sent-events/src/server_sent_events/service.clj
+++ b/content/guides/server-sent-events/src/server_sent_events/service.clj
@@ -1,0 +1,180 @@
+;; tag::original-service[]
+(ns server-sent-events.service
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.http.body-params :as body-params]
+            [ring.util.response :as ring-resp]))
+
+(defn about-page
+  [request]
+  (ring-resp/response (format "Clojure %s - served from %s"
+                              (clojure-version)
+                              (route/url-for ::about-page))))
+
+(defn home-page
+  [request]
+  (ring-resp/response "Hello World!"))
+
+;; Defines "/" and "/about" routes with their associated :get handlers.
+;; The interceptors defined after the verb map (e.g., {:get home-page}
+;; apply to / and its children (/about).
+(def common-interceptors [(body-params/body-params) http/html-body])
+
+;; Tabular routes
+(def routes #{["/" :get (conj common-interceptors `home-page)]
+              ["/about" :get (conj common-interceptors `about-page)]})
+
+;; Map-based routes
+;(def routes `{"/" {:interceptors [(body-params/body-params) http/html-body]
+;                   :get home-page
+;                   "/about" {:get about-page}}})
+
+;; Terse/Vector-based routes
+;(def routes
+;  `[[["/" {:get home-page}
+;      ^:interceptors [(body-params/body-params) http/html-body]
+;      ["/about" {:get about-page}]]]])
+
+
+;; Consumed by server-sent-events.server/create-server
+;; See http/default-interceptors for additional options you can configure
+(def service {:env :prod
+              ;; You can bring your own non-default interceptors. Make
+              ;; sure you include routing and set it up right for
+              ;; dev-mode. If you do, many other keys for configuring
+              ;; default interceptors will be ignored.
+              ;; ::http/interceptors []
+              ::http/routes routes
+
+              ;; Uncomment next line to enable CORS support, add
+              ;; string(s) specifying scheme, host and port for
+              ;; allowed source(s):
+              ;;
+              ;; "http://localhost:8080"
+              ;;
+              ;;::http/allowed-origins ["scheme://host:port"]
+
+              ;; Tune the Secure Headers
+              ;; and specifically the Content Security Policy appropriate to your service/application
+              ;; For more information, see: https://content-security-policy.com/
+              ;;   See also: https://github.com/pedestal/pedestal/issues/499
+              ;;::http/secure-headers {:content-security-policy-settings {:object-src "'none'"
+              ;;                                                          :script-src "'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:"
+              ;;                                                          :frame-ancestors "'none'"}}
+
+              ;; Root for resource interceptor that is available by default.
+              ::http/resource-path "/public"
+
+              ;; Either :jetty, :immutant or :tomcat (see comments in project.clj)
+              ;;  This can also be your own chain provider/server-fn -- http://pedestal.io/reference/architecture-overview#_chain_provider
+              ::http/type :jetty
+              ;;::http/host "localhost"
+              ::http/port 8080
+              ;; Options to pass to the container (Jetty)
+              ::http/container-options {:h2c? true
+                                        :h2? false
+                                        ;:keystore "test/hp/keystore.jks"
+                                        ;:key-password "password"
+                                        ;:ssl-port 8443
+                                        :ssl? false}})
+;; end::original-service[]
+
+;; tag::cleaned-up[]
+(ns server-sent-events.service
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.http.body-params :as body-params]
+            [ring.util.response :as ring-resp]))
+
+(defn home-page
+  [request]
+  (ring-resp/response "Hello World!"))
+
+(def routes
+ `[[["/" {:get home-page}]]])
+
+(def service {:env :prod
+              ::http/routes routes
+              ::http/type :jetty
+              ::http/port 8080})
+;; end::cleaned-up[]
+
+;; tag::require-sse[]
+(ns server-sent-events.service
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
+            ;; require SSE
+            [io.pedestal.http.sse :as sse]
+            [io.pedestal.http.body-params :as body-params]
+            [ring.util.response :as ring-resp]
+            ;; require core.async
+            [clojure.core.async :as async]))
+;; end::require-sse[]
+
+(defn home-page
+  [request]
+  (ring-resp/response "Hello World!"))
+
+;; tag::html-home[]
+(ns server-sent-events.service
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.http.sse :as sse]
+            [io.pedestal.http.body-params :as body-params]
+            [ring.util.response :as ring-resp]
+            [clojure.core.async :as async]
+            [hiccup.core :as hiccup]))
+
+(def js-string
+  "
+var eventSource = new EventSource(\"http://localhost:8080/counter\");
+eventSource.addEventListener(\"counter\", function(e) {
+  console.log(e);
+  var counterEl = document.getElementById(\"counter\");
+  counter.innerHTML = e.data;
+});
+")
+
+(defn home-page
+  [request]
+  {:status 200
+   :headers {"Content-Type" "text/html"}
+   :body (hiccup/html [:html
+                       [:head
+                        [:script {:type "text/javascript"}
+                         js-string]]
+                       [:body
+                        [:div
+                         [:span "Counter: "]
+                         [:span#counter]]]])})
+
+(defn stream-ready [event-chan context]
+  (dotimes [i 10]
+    (async/>!! event-chan {:name "counter" :data i})
+    (Thread/sleep 1000))
+  (async/close! event-chan))
+
+(def routes
+  `[[["/" {:get home-page}
+      ["/counter" {:get [::send-counter (sse/start-event-stream stream-ready)]}]]]])
+
+(def service {:env :prod
+              ::http/routes routes
+              ::http/type :jetty
+              ::http/port 8080
+              ;; we need this so we can use inline scripts
+              ::http/secure-headers {:content-security-policy-settings {:object-src "none"}}})
+;; end::html-home[]
+
+;; tag::counter-route[]
+(defn stream-ready [event-chan context]
+  (dotimes [i 10]
+    (async/>!! event-chan {:name "counter" :data i})
+    (Thread/sleep 1000))
+  (async/close! event-chan))
+
+(def routes
+  `[[["/" {:get home-page}
+      ["/counter" {:get [::send-counter (sse/start-event-stream stream-ready)]}]]]])
+;; end::counter-route[]
+;; end::add-sse-counter[]

--- a/content/guides/server-sent-events/test/server_sent_events/service_test.clj
+++ b/content/guides/server-sent-events/test/server_sent_events/service_test.clj
@@ -1,0 +1,39 @@
+(ns server-sent-events.service-test
+  (:require [clojure.test :refer :all]
+            [io.pedestal.test :refer :all]
+            [io.pedestal.http :as bootstrap]
+            [server-sent-events.service :as service]))
+
+(def service
+  (::bootstrap/service-fn (bootstrap/create-servlet service/service)))
+
+(deftest home-page-test
+  (is (=
+       (:body (response-for service :get "/"))
+       "Hello World!"))
+  (is (=
+       (:headers (response-for service :get "/"))
+       {"Content-Type" "text/html;charset=UTF-8"
+        "Strict-Transport-Security" "max-age=31536000; includeSubdomains"
+        "X-Frame-Options" "DENY"
+        "X-Content-Type-Options" "nosniff"
+        "X-XSS-Protection" "1; mode=block"
+        "X-Download-Options" "noopen"
+        "X-Permitted-Cross-Domain-Policies" "none"
+        "Content-Security-Policy" "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"})))
+
+(deftest about-page-test
+  (is (.contains
+       (:body (response-for service :get "/about"))
+       "Clojure 1.8"))
+  (is (=
+       (:headers (response-for service :get "/about"))
+       {"Content-Type" "text/html;charset=UTF-8"
+        "Strict-Transport-Security" "max-age=31536000; includeSubdomains"
+        "X-Frame-Options" "DENY"
+        "X-Content-Type-Options" "nosniff"
+        "X-XSS-Protection" "1; mode=block"
+        "X-Download-Options" "noopen"
+        "X-Permitted-Cross-Domain-Policies" "none"
+        "Content-Security-Policy" "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"})))
+


### PR DESCRIPTION
Populated the server-sent event page in the guides section with a tutorial on how to add a server-sent event route using the latest SSE api and a basic example of how to consume the event stream from JavaScript. Also generated the content/guides/server-sent-events directory containing a project generated using:
```
lein new pedestal-server server-sent-events
```
and modified with the example code.