### PR TITLE
Fix wrong key path to content-type value

### DIFF
--- a/content/guides/hello-content/src/hello.clj
+++ b/content/guides/hello-content/src/hello.clj
@@ -136,7 +136,7 @@
    :leave
    (fn [context]
      (cond-> context
-       (nil? (get-in context [:response :body :headers "Content-Type"]))              ;; <1>
+       (nil? (get-in context [:response :headers "Content-Type"]))                    ;; <1>
        (update-in [:response] coerce-to (accepted-type context))))})                  ;; <2>
 
                                                                                       ;; end::coerce_body_2[]


### PR DESCRIPTION
Remove the `:body` key for selecting the Content-Type in the request header.