### PR TITLE
Explictly say the default for ::http/host

### DIFF
--- a/content/reference/service-map.adoc
+++ b/content/reference/service-map.adoc
@@ -63,7 +63,7 @@ and their behaviour will remain unspecified.
 | `::http/host`
 | N
 | String
-| Hostname, e.g., "localhost". Passed to the container.
+| Hostname, e.g., "localhost". Passed to the container. Defaults to `localhost`.
 
 | `::http/interceptors`
 | N


### PR DESCRIPTION
By default other's set this value to "0.0.0.0" which is more unsafe, however, when giving the user sane defaults it's nice to know what the actual value is.

Personally, I didn't know that this was being set to "localhost" as the documentation says:

> ...e.g., "localhost"...

Which doesn't necessarily mean it's being set to "localhost" just that you might set it to something _like_ "localhost".