### PR TITLE
Fix adoc links

### DIFF
--- a/content/samples/index.adoc
+++ b/content/samples/index.adoc
@@ -6,16 +6,16 @@ Document Writer
 :icons: font
 
 * https://github.com/pedestal/pedestal/tree/master/samples/aws-codestar-lambda[aws-codestar-lambda] - This is an example on running a Pedestal Service on AWS Lambda via API Gateway.
-It's designed to be a [CodeStar](https://aws.amazon.com/codestar/) project and ships with CodePipeline and CloudFormation support.
+It's designed to be a https://aws.amazon.com/codestar/[CodeStar] project and ships with CodePipeline and CloudFormation support.
 * https://github.com/pedestal/pedestal/tree/master/samples/buddy-auth[buddy-auth] - This sample demonstrates integration with
-the [buddy-auth](https://funcool.github.io/buddy-auth/latest/) library
+the https://funcool.github.io/buddy-auth/latest/[buddy-auth] library
 using a Basic Authentication backend. In the process, it demonstrates
 how to port buddy-auth's `wrap-authentication` and
 `wrap-authorization` middleware functions to interceptors.
 * https://github.com/pedestal/pedestal/tree/master/samples/chain-providers[chain-providers] - This sample demonstrates using Pedestal with a custom backend server.
 Interceptor Chain Providers allow Pedestal to be used on top of any HTTP Server that's supported on the JVM.
 * https://github.com/pedestal/pedestal/tree/master/samples/cors[cors] - Here we demonstrate an implementation 
-of [cross-origin resource sharing](http://en.wikipedia.org/wiki/Cross-origin_resource_sharing).
+of http://en.wikipedia.org/wiki/Cross-origin_resource_sharing[cross-origin resource sharing].
 * https://github.com/pedestal/pedestal/tree/master/samples/fast-pedestal[fast-pedestal] - This sample illustrates various techniques to reduce latency and increase throughput/goodput.
 * https://github.com/pedestal/pedestal/tree/master/samples/hello-world[hello-world] - A bare-minimum Pedestal service that greets visitors.
 * https://github.com/pedestal/pedestal/tree/master/samples/helloworld-metrics[helloworld-metrics] - Pedestal offers metrics logging capabilities starting with Pedestal-0.5.0.
@@ -27,7 +27,7 @@ that resolves to a 0-arity function or nil.
 That function should return something that satisfies the MetricRecorder protocol.
 * https://github.com/pedestal/pedestal/tree/master/samples/http2[http2] - This very simple app demonstrates using Jetty's HTTP2 capabilties.
 * https://github.com/pedestal/pedestal/tree/master/samples/http2-conscrypt[http2-conscrypt] - This very simple app demonstrates using Jetty's HTTP2 capabilties.
-* https://github.com/pedestal/pedestal/tree/master/samples/immutant[immutant] - This is the `hello-world` example, adpted to illustrate using [Immutant](http://immutant.org).
+* https://github.com/pedestal/pedestal/tree/master/samples/immutant[immutant] - This is the `hello-world` example, adpted to illustrate using http://immutant.org[Immutant].
 * https://github.com/pedestal/pedestal/tree/master/samples/jetty-web-sockets[jetty-web-sockets] - This sample illustrates how to use WebSockets with Pedestal and Jetty.
 * https://github.com/pedestal/pedestal/tree/master/samples/nio[nio] - This sample demonstrates using a ByteBuffer as a response body. For large response
 amidst a high number of concurrent connections, using NIO (via a ByteBuffer or


### PR DESCRIPTION
This is a minor change to fix links. Previously, it looked like the Markdown link syntax was used instead of AsciiDoc's.