### PR TITLE
Correct typos in "interceptor" usage

### DIFF
--- a/content/guides/hello-world-content-types.adoc
+++ b/content/guides/hello-world-content-types.adoc
@@ -140,7 +140,7 @@ image::../images/guides/interceptors.png[]
 That context map contains the request map, the response map, and a
 queue of interceptors that still need to be invoked.
 
-An interceptors `enter` function is called on the way "down" the
+An interceptor's `enter` function is called on the way "down" the
 queue. Each `enter` function will be called in order. As interceptors
 are entered, they get pushed on to a stack to be called in reverse on
 the way back "up". Once the interceptor queue is empty, the `leave`

--- a/content/guides/index.adoc
+++ b/content/guides/index.adoc
@@ -38,7 +38,7 @@ Cognitect
 
 == Fun with Interceptors
 
-* An Interceptors that adds Interceptors
+* An Interceptor that adds Interceptors
 * Writing a Custom Router
 
 == Security


### PR DESCRIPTION
Corrects simple typos found while working pedestal/pedestal/issues/550. These typos are otherwise less likely to be changed in the course of that work

1) ”An Interceptor~~s̶~~"
2) ”interceptor's" replaces "interceptors" for possessive usage