### PR TITLE
Add async-downstream interceptor warning

### DIFF
--- a/content/reference/interceptors.adoc
+++ b/content/reference/interceptors.adoc
@@ -150,6 +150,10 @@ expect an asynchronous response.
                 (assoc context :auth-response (call-auth-system context))))})
 ----
 
+[IMPORTANT]
+.*Chaining With Async Interceptors*
+Any interceptor downstream of an asynchronous interceptor will be executed in the `core.async` thread pool.
+
 === IntoInterceptor
 
 The protocol


### PR DESCRIPTION
Addresses #126 

Some very simple work to make the thread execution locality of interceptors downstream of an async interceptor crystal clear.

Happy to hear thoughts on if this fits the bill for the "bright flashing letters" sensibly requested by [@mullr](https://github.com/mullr) in the [originating issue](https://github.com/pedestal/pedestal/issues/550) on the code side.