### PR TITLE
Headers are required for a valid response map

### DIFF
--- a/content/reference/response-map.adoc
+++ b/content/reference/response-map.adoc
@@ -22,7 +22,7 @@ processing is done, Pedestal generates a 404 response.
 | The HTTP status code
 
 | `:headers`
-| N
+| Y
 | map of String -> String
 | Response headers sent to the client. Header names are all converted to lower case.
 


### PR DESCRIPTION
See this function, which pedestal uses internally, e.g., for checking if it should do early termination. 
https://github.com/ring-clojure/ring/blob/45413f63121a6ec5511aca6f4d7e470f39a72a27/ring-core/src/ring/util/response.clj#L242