### PR TITLE
Add cookbook entry on overriding logging

### DIFF
--- a/content/cookbook/index.adoc
+++ b/content/cookbook/index.adoc
@@ -75,3 +75,45 @@ Reference: link:../reference/table-syntax#_http_verb[Table Syntax Http Verb]
 ----
 include::src/verb_neutral_routes/service.clj[tags=routes]
 ----
+
+== How to override request logging
+
+The `log-request` is always added as the first of the link:../reference/default-interceptors[default interceptors].
+This will log requests as they come in (using `io.pedestal.log`), according to how your logging infrastructure
+is configured.
+
+The default logger will output something like:
+
+----
+INFO io.pedestal.log {:msg "GET /status", :line 80}
+----
+
+To disable the log entirely, set the logger to `nil` in the link:../reference/service-map[service map]:
+
+[source,clojure]
+----
+(-> {::http/request-logger nil}
+    http/default-interceptors)
+----
+
+=== Custom log format
+
+To modify the log message, for example, to log request timing, you can use a custom interceptor.
+In this example, we use `io.pedestal.log`, but you can freely use
+link:https://github.com/clojure/tools.logging[`org.clojure/tools.logging`] or
+any other logging mechanism.
+
+[[cookbook-listing]]
+[source,clojure]
+----
+include::src/logging/service.clj[]
+----
+
+This will output something like:
+
+----
+INFO logging.service {:method "GET", :msg "request completed", :line "24", :status 200, :uri "/status", :response-time 5}
+----
+
+This can obviously be extended to log unique request ids, user details,
+`:json-params` from the body or anything else as required.

--- a/content/cookbook/src/logging/service.clj
+++ b/content/cookbook/src/logging/service.clj
@@ -1,0 +1,32 @@
+(ns logging.service
+  (:require [io.pedestal.http :as http]
+            [io.pedestal.http.route :as route]
+            [io.pedestal.interceptor :refer [interceptor]]
+            [io.pedestal.log :as log]
+            [ring.util.response :as ring-resp]))
+
+(def log-request
+  "Logs all http requests with response time."
+  {:name ::log-request
+   :enter (fn [context]
+              (assoc-in context [:request :start-time] (System/currentTimeMillis)))
+   :leave (fn [context]
+              (let [{:keys [uri start-time request-method]} (:request context)
+                    finish (System/currentTimeMillis)
+                    total (- finish start-time)]
+                   (log/info :msg "request completed"
+                             :method (clojure.string/upper-case (name request-method))
+                             :uri uri
+                             :status (:status (:response context))
+                             :response-time total)))})
+
+(defn home-page
+  [request]
+  (ring-resp/response "Hello World!"))
+
+(def routes #{["/" :get `home-page]})
+
+(def service {::http/routes            routes
+              ::http/request-logger    (interceptor log-request)
+              ::http/type              :jetty
+              ::http/port              8080})


### PR DESCRIPTION
This PR creates a cookbook entry on overriding logging, as requested in https://github.com/pedestal/pedestal-docs/pull/146#issuecomment-760386083


As discussed in #149 , I do think the cookbook section could be merged into the reference section so readers don't need to jump around the docs so much to patch together their knowledge. But that is a larger change that warrants more discussion.