### PR TITLE
Correcting directory

### DIFF
--- a/content/guides/hello-world.adoc
+++ b/content/guides/hello-world.adoc
@@ -258,7 +258,7 @@ link:https://clojure.org/guides/deps_and_cli[learn more], then come
 back and we'll continue.
 
 Now we can make a `deps.edn` that tells the `clj` tool what libraries our
-service needs. This goes in the main directory `hello`:
+service needs. This goes in the main directory `hello-world`:
 
 [[app-listing]]
 [source,clojure]


### PR DESCRIPTION
The instructions [here](http://pedestal.io/guides/hello-world#_starting_from_scratch) specify that this app be created in a `hello-world` directory. I've updated a line that refers to a `hello` directory to refer to the `hello-world` directory.