### PR TITLE
Document all `::http/secure-headers` options

### DIFF
--- a/content/reference/service-map.adoc
+++ b/content/reference/service-map.adoc
@@ -204,6 +204,18 @@ If the key is simply not present in the service map, then a set of default secur
 | X-XSS-Protection
 | "1; mode=block"
 
+| `:download-options-settings`
+| X-Download-Options
+| "noopen"
+
+| `:cross-domain-policies-settings`
+| X-Permitted-Cross-Domain-Policies
+| "none"
+
+| `:content-security-policy-settings`
+| Content-Security-Policy
+| "object-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' 'strict-dynamic' https: http:;"
+
 |===
 
 If the value for `::http/secure-headers` is present, it may contain


### PR DESCRIPTION
Mention all options for `::http/secure-headers` in the docs.

I pulled the default values from the doc-strings:
- http://pedestal.io/api/pedestal.service/io.pedestal.http.html#var-default-interceptors
- http://pedestal.io/api/pedestal.service/io.pedestal.http.secure-headers.html#var-secure-headers