### PR TITLE
Clean up discussion of interceptors

### DIFF
--- a/content/reference/architecture-overview.adoc
+++ b/content/reference/architecture-overview.adoc
@@ -38,7 +38,7 @@ And with a variety of network connectors:
 One more dimension of complexity arises from the relevant styles of
 application we want to support:
 
-- API + SPA
+- An API supporting a SPA (Single Page Application)
 - Streaming events
 - Server-rendered pages
 
@@ -49,17 +49,59 @@ image::../images/reference/pedestal-fundament.png[]
 
 === Interceptors
 
-In their original form, interceptors were a way to _reify the
-callstack_ of request processing. That is to say, what would normally
-be a layered jawbreaker of function closures became a sequence of data
-structures. This model has allowed us to extract an increasing amount
-of logic from the core framework into interceptors. For example,
-routing is usually implemented as a core function of a web
-framework. Because an interceptor can enqueue more interceptors to
-execute, Pedestal implements routing as an ordinary interceptor.
+Before Pedestal, there was another popular Clojure web framework, https://github.com/ring-clojure/ring[Ring].
+In Ring, each _route_ (a combination of an HTTP method and a path pattern) is mapped to a handler:
+the handler is just a simple function: the function accepts a request map and returns a response map.
 
-Over time, we have moved most of the functionality of a typical web
-framework into interceptors:
+Because a server is more than a single route, and because many routes will share a lot of behavior such as logging,
+authentication, response rendering, and parameter parsing, each individual Ring route is wrapped in _middleware_,
+a function that wraps an existing handler and returns a new handler.
+Middleware can inspect and modify the incoming request map or the outgoing response map.
+
+For example, maybe your application wants to respond specially to HEAD requests;
+
+[source,clojure]
+----
+include::src/org/example/middleware.clj[]
+----
+<1> This is the returned handler, wrapping around the original handler
+<2> Ring specifies at set of keys for the request map; Pedestal follows the same rules
+<3> Ring specifies another set of keys for the response map
+<4> Here's where we delegate down to the next handler
+
+This is good, functional design, but is limited in at least one way: it's all on the stack of a single request processing thread.
+Given how great Clojure is at multithreaded programming, that can be a limitation.
+Several of the central features of Pedestal (such as streaming events and web socket connections) are at odds with this:
+in these cases a long-running server-side process only _occasionally_ needs a request processing thread to send an event,
+or web socket message, to the client.
+
+So, in Pedestal we want something as easily reused and composable as Ring middleware functions, but something that can break free of
+the limiting stack-of-function-calls invocation model.
+That's interceptors.
+
+An interceptor is a bundle of up-to three functions, named :enter, :leave, and :error.
+:enter corresponds to the logic before delegating to the next interceptor; the request can be inspected or modified.
+Likewise, :leave corresponds to logic that occurs _after_ a response map has been created.  The :error function
+is used when an interceptor throws an exception; it's the interceptor version of a `(try ... catch ...)`.
+
+Now, there's a bit more going on.  First, these :enter and :leave callbacks are passed a _context_ map which
+contains a :request key.
+Any interceptor can modify the context map: some may modify the :request map inside the context, others may
+attach a :response map to the context.
+
+Inside the context is a chain of interceptors.
+Pedestal works its way down the chain, calling :enter callbacks, until some interceptor attaches a :response map to the context;
+then it works its way back up the chain, calling :leave callbacks.
+
+In practice, an interceptor looks like a normal Clojure map with keys :enter, :leave, or :error (usually just one of these).
+So, unlike a deeply wrapped function, a chain of interceptors is a data structure that can be inspected by a developer,
+or modified in code.
+
+Once you realize that an interceptor can _add_ new interceptors to the chain (because the interceptor chain itself is stored
+in the context, alongside the :request map) then new options open up; for example, routing is just an interceptor
+that works with a data structure identifying HTTP methods and URL path patterns, and adds new interceptors to the chain.
+
+Pedestal includes general purpose interceptors for all sorts of typical web request functionality:
 
 - Content negotiation
 - Request body parsing
@@ -67,16 +109,12 @@ framework into interceptors:
 - Parsing query parameters
 - Assigning content type to the response
 
-Application logic is also implemented in interceptors.
+Application logic is also implemented as interceptors, though there's some simple helpers that allow you to write
+these as Ring-style handlers, if you like.
 
-An interceptor may return a channel instead of the context map. In
-that case, the channel is treated like a promise to deliver the
-context map in the future. Once the channel delivers the context map,
-the chain executor closes the channel.
-
-The key protocol for interceptors is:
-
-- link:../api/io.pedestal.interceptor.html#var-IntoInterceptor[`IntoInterceptor`]
+But Pedestal has one more big trick up its sleeve: any interceptor may, instead of returning a context map,
+instead return a https://github.com/clojure/core.async[core.async] channel that conveys the context map at some point
+in the future; this is what breaks request processing away from the request processing threads.
 
 === Stock Interceptors
 

--- a/content/reference/architecture-overview.adoc
+++ b/content/reference/architecture-overview.adoc
@@ -20,32 +20,39 @@ framework must solve certain common problems:
 There is an unstated requirement that these all work in a variety of
 deployment environments:
 
-- Jar
-- Exploded jar
-- Container
-- Unikernel
+- Local development of a workspace
+- Packaged into a Jar file
+- An exploded version of a packaged Jar file
+- Packaged into a Docker container
 
-And with a variety of network connectors:
+Further, different teams prefer a variety of different request handling frameworks:
 
 - Tomcat
 - Jetty
 - Undertow
 - Netty
-- nginx
 - Vert.x
 - etc.
 
 One more dimension of complexity arises from the relevant styles of
 application we want to support:
 
+- Traditional server-rendered pages
 - An API supporting a SPA (Single Page Application)
 - Streaming events
-- Server-rendered pages
 
-Solving these problems led us to an architecture that is based on
-interceptors, the context map, and an adaptor to the HTTP connector.
+Importantly, supporting streaming events and web sockets are explicitly asynchronous.
+
+Addressing all of these requirements led us to an architecture that is based on
+_interceptors_, the context map, and an adaptor to the HTTP network connector (for the underlying
+request handling framework).
 
 image::../images/reference/pedestal-fundament.png[]
+
+Here, the network occurs at the bottom of the diagram; the interceptor chain provider
+is initialized with the incoming request, and a series of Pedestal and application-specific
+interceptors perform the bulk of the work, resulting in a response that flows back to the
+network connector to be conveyed to the originating client.
 
 === Interceptors
 
@@ -58,7 +65,7 @@ authentication, response rendering, and parameter parsing, each individual Ring 
 a function that wraps an existing handler and returns a new handler.
 Middleware can inspect and modify the incoming request map or the outgoing response map.
 
-For example, maybe your application wants to respond specially to HEAD requests;
+For example, perhaps your application needs to respond specially to HEAD requests;
 
 [source,clojure]
 ----
@@ -79,29 +86,29 @@ So, in Pedestal we want something as easily reused and composable as Ring middle
 the limiting stack-of-function-calls invocation model.
 That's interceptors.
 
-An interceptor is a bundle of up-to three functions, named :enter, :leave, and :error.
-:enter corresponds to the logic before delegating to the next interceptor; the request can be inspected or modified.
-Likewise, :leave corresponds to logic that occurs _after_ a response map has been created.  The :error function
-is used when an interceptor throws an exception; it's the interceptor version of a `(try ... catch ...)`.
+An interceptor is a bundle of up-to three functions, named `:enter`, `:leave`, and `:error`.
+`:enter` corresponds to the logic before delegating to the next interceptor; the request can be inspected or modified.
+Likewise, `:leave` corresponds to logic that occurs _after_ a response map has been created.
+The `:error` function is used when an interceptor throws an exception; it's the interceptor version of a `(try ... catch ...)`.
 
-Now, there's a bit more going on.  First, these :enter and :leave callbacks are passed a _context_ map which
-contains a :request key.
-Any interceptor can modify the context map: some may modify the :request map inside the context, others may
-attach a :response map to the context.
+Now, there's a bit more going on.  First, these `:enter` and `:leave` callbacks are passed a _context_ map which
+contains a `:request` key.
+Any interceptor can modify the context map: some may modify the `:request` map inside the context, others may
+attach a `:response` map to the context.
 
 Inside the context is a chain of interceptors.
-Pedestal works its way down the chain, calling :enter callbacks, until some interceptor attaches a :response map to the context;
-then it works its way back up the chain, calling :leave callbacks.
+Pedestal works its way down the chain, calling :enter callbacks, until some interceptor attaches a
+`:response` map to the context;
+then it works its way back up the chain, calling `:leave` callbacks.
 
-In practice, an interceptor looks like a normal Clojure map with keys :enter, :leave, or :error (usually just one of these).
-So, unlike a deeply wrapped function, a chain of interceptors is a data structure that can be inspected by a developer,
-or modified in code.
+In practice, an interceptor looks like a normal Clojure map with keys `:enter`, `:leave`, or `:error` (usually just one of these).
+So, unlike a deeply wrapped function, a chain of interceptors is a data structure that can be inspected by a developer, or manipulated in code.
 
-Once you realize that an interceptor can _add_ new interceptors to the chain (because the interceptor chain itself is stored
-in the context, alongside the :request map) then new options open up; for example, routing is just an interceptor
+Importantly, an interceptor can _add_ new interceptors to the chain (because the interceptor chain itself is stored
+in the context, alongside the `:request` map).  Because of this, routing is just an interceptor
 that works with a data structure identifying HTTP methods and URL path patterns, and adds new interceptors to the chain.
 
-Pedestal includes general purpose interceptors for all sorts of typical web request functionality:
+Pedestal includes general purpose interceptors for all sorts of typical HTTP request functionality:
 
 - Content negotiation
 - Request body parsing
@@ -114,31 +121,9 @@ these as Ring-style handlers, if you like.
 
 But Pedestal has one more big trick up its sleeve: any interceptor may, instead of returning a context map,
 instead return a https://github.com/clojure/core.async[core.async] channel that conveys the context map at some point
-in the future; this is what breaks request processing away from the request processing threads.
+in the future; this is what allows for asynchronous request processing.
 
-=== Stock Interceptors
-
-The link:../api/index.html[`pedestal-service`] library includes a large set of interceptors
-that are specialized for HTTP request handling.
-
-See the following namespaces for stock interceptors:
-
-- link:../api/io.pedestal.http.body-params.html[`io.pedestal.http.body-params`]
-- link:../api/io.pedestal.http.content-negotiation.html[`io.pedestal.http.content-negotiation`]
-- link:../api/io.pedestal.http.cors.html[`io.pedestal.http.cors`]
-- link:../api/io.pedestal.http.csrf.html[`io.pedestal.http.csrf`]
-- link:../api/io.pedestal.http.ring-middlewares.html[`io.pedestal.http.ring-middlewares`]
-
-See the following namespaces for routing interceptors:
-
-- link:../api/io.pedestal.http.route.html[`io.pedestal.http.route`]
-- link:../api/io.pedestal.http.route.router.html[`io.pedestal.http.route.router`]
-
-=== Context Bindings
-
-Interceptors expect certain keys to be present in the context
-map. These _context bindings_ are part of the contract between
-provider and interceptors.
+Further details are in the link:interceptors[interceptors reference].
 
 === Chain Provider
 

--- a/content/reference/architecture-overview.adoc
+++ b/content/reference/architecture-overview.adoc
@@ -104,7 +104,7 @@ Pedestal works its way through the queue, calling `:enter` callbacks, until some
 `:response` map to the context;
 then it works its way backwards, calling `:leave` callbacks.
 
-In practice, an interceptor looks like a normal Clojure map with keys `:enter`, `:leave`, or `:error` (usually just one of these).
+In practice, an interceptor looks like a normal Clojure map with keys `:enter`, `:leave`, or `:error` (usually just `:enter` and/or `:leave`).
 So, unlike a deeply wrapped function, a chain of interceptors is a data structure that can be inspected by a developer, or manipulated in code.
 
 Importantly, any interceptor can _add_ new interceptors to the queue (because the interceptor queue itself is stored

--- a/content/reference/architecture-overview.adoc
+++ b/content/reference/architecture-overview.adoc
@@ -56,16 +56,19 @@ network connector to be conveyed to the originating client.
 
 === Interceptors
 
-Before Pedestal, there was another popular Clojure web framework, https://github.com/ring-clojure/ring[Ring].
+Pedestal is far from the first web framework for Clojure, and attempts to expand on ideas
+piloted elsewhere.
+https://github.com/ring-clojure/ring[Ring] is likely the most popular and influential.
 In Ring, each _route_ (a combination of an HTTP method and a path pattern) is mapped to a handler:
-the handler is just a simple function: the function accepts a request map and returns a response map.
+the handler is just a simple function which accepts a request map as its input, and
+returns a response map.
 
 Because a server is more than a single route, and because many routes will share a lot of behavior such as logging,
 authentication, response rendering, and parameter parsing, each individual Ring route is wrapped in _middleware_,
 a function that wraps an existing handler and returns a new handler.
 Middleware can inspect and modify the incoming request map or the outgoing response map.
 
-For example, perhaps your application needs to respond specially to HEAD requests;
+For example, perhaps your Ring application needs to respond specially to HEAD requests;
 
 [source,clojure]
 ----
@@ -82,8 +85,8 @@ Several of the central features of Pedestal (such as streaming events and web so
 in these cases a long-running server-side process only _occasionally_ needs a request processing thread to send an event,
 or web socket message, to the client.
 
-So, in Pedestal we want something as easily reused and composable as Ring middleware functions, but something that can break free of
-the limiting stack-of-function-calls invocation model.
+So, in Pedestal we want something as easily reused and composable as Ring middleware functions, without
+the limitations of the stack-of-function-calls invocation model.
 That's interceptors.
 
 An interceptor is a bundle of up-to three functions, named `:enter`, `:leave`, and `:error`.
@@ -96,17 +99,18 @@ contains a `:request` key.
 Any interceptor can modify the context map: some may modify the `:request` map inside the context, others may
 attach a `:response` map to the context.
 
-Inside the context is a chain of interceptors.
-Pedestal works its way down the chain, calling :enter callbacks, until some interceptor attaches a
+Inside the context is a queue of interceptors.
+Pedestal works its way through the queeu, calling `:enter` callbacks, until some interceptor attaches a
 `:response` map to the context;
-then it works its way back up the chain, calling `:leave` callbacks.
+then it works its way backwards, calling `:leave` callbacks.
 
 In practice, an interceptor looks like a normal Clojure map with keys `:enter`, `:leave`, or `:error` (usually just one of these).
 So, unlike a deeply wrapped function, a chain of interceptors is a data structure that can be inspected by a developer, or manipulated in code.
 
-Importantly, an interceptor can _add_ new interceptors to the chain (because the interceptor chain itself is stored
-in the context, alongside the `:request` map).  Because of this, routing is just an interceptor
-that works with a data structure identifying HTTP methods and URL path patterns, and adds new interceptors to the chain.
+Importantly, any interceptor can _add_ new interceptors to the queue (because the interceptor queue itself is stored
+in the context, alongside the `:request` map).  Because of this,
+link:routing-quick-reference[request routing] boils down to an interceptor
+that peeks at the request and makes decisions about what additional interceptors to add to the queue.
 
 Pedestal includes general purpose interceptors for all sorts of typical HTTP request functionality:
 

--- a/content/reference/architecture-overview.adoc
+++ b/content/reference/architecture-overview.adoc
@@ -100,7 +100,7 @@ Any interceptor can modify the context map: some may modify the `:request` map i
 attach a `:response` map to the context.
 
 Inside the context is a queue of interceptors.
-Pedestal works its way through the queeu, calling `:enter` callbacks, until some interceptor attaches a
+Pedestal works its way through the queue, calling `:enter` callbacks, until some interceptor attaches a
 `:response` map to the context;
 then it works its way backwards, calling `:leave` callbacks.
 

--- a/content/reference/interceptors.adoc
+++ b/content/reference/interceptors.adoc
@@ -246,6 +246,13 @@ because interceptor representations are transformed to `Interceptor`
 records during route expansion.
 --
 
+It's worth noting that when an interceptor queues additional interceptors for execution,
+they execute after all interceptors already in the queue (not after the interceptor that
+modified the queue).  This means you could, for example, put a routing interceptor first
+in the queue, then a few interceptors that provide behavior common to all routes and those
+common interceptors will run before any route-specific interceptors.
+
+
 === Handlers
 
 A "handler" function is a special case of an interceptor. It plays the
@@ -265,7 +272,7 @@ position of a stack.
 Pedestal supports defining interceptor-specific error handlers via the
 `:error` key. Refer to the link:error-handling[Error Handling] reference for more details.
 
-=== Stock Interceptors
+=== Pedestal Interceptors
 
 The link:../api/pedestal.service/index.html[`pedestal-service`] library includes a large set of interceptors
 that are specialized for HTTP request handling.

--- a/content/reference/interceptors.adoc
+++ b/content/reference/interceptors.adoc
@@ -59,7 +59,7 @@ A basic interceptor is shown here.
 ----
 (def attach-guid
   {:name ::attach-guid
-   :enter (fn [context] (assoc context ::guid (java.util.UUID/randomUUID)))})
+   :enter (fn [context] (assoc context ::guid (random-uuid)))})
 ----
 
 This interceptor has only the `:enter` function. Interceptors
@@ -100,10 +100,15 @@ HTTP request with additional functionality. For example:
                 context))})
 ----
 
-Notice that this interceptor expects some other interceptor(s) to add
-data to the context using the `::tx-data` key.
+This interceptor's job is to apply a side effect change the the `database` atom.
+Some other interceptor, further down the chain, will have attached the `::tx-data` key
+to the context, and this interceptor's job is to apply the change.
 
-Interceptors are values but they are not required to be compile-time
+This is a good division of labor, as the other interceptor will be more truly functional (accepting
+and returning values with no side effects); the "dirty" side-effecting behavior is localized to this
+one interceptor.
+
+Although interceptors are values, they are not required to be compile-time
 values. Functions can close over state and return interceptors. Some
 frequently-used built-ins work this way. (E.g.,
 link:../api/io.pedestal.http.body-params.html#var-body-params[`body-params`].)
@@ -122,6 +127,18 @@ the database connection to every request:
 In addition to closing over the argument `uri`, we're using an
 anonymous function for the `:enter` function here.
 
+=== Context Bindings
+
+Interceptors expect certain keys to be present in the context
+map. These _context bindings_ are part of the contract between
+provider and interceptors.
+
+The most common context key is `:request`, which holds the
+https://github.com/ring-clojure/ring/blob/master/SPEC[Ring-specified request map].
+
+Further, an interceptor terminates the processing chain by attaching
+a `:response map` (also specified by Ring) to the context.
+
 === Interceptor Return Values
 
 Interceptor functions must return values. Returning `nil` will cause
@@ -130,12 +147,13 @@ an internal server error.
 An `:enter` or `:leave` function may return a context map directly. In
 this case, processing continues with the next interceptor.
 
-If the interceptor will take a long time to return a result, it may
-also return a core.async channel. Pedestal will yield the thread and
-wait for a value to be produced. Only one value will be consumed from
-this channel, and it must be a context map.
+If the interceptor is expected to take a long time to return a result, it may
+instead return a core.async channel. Pedestal will yield the request processing thread and
+wait for a value to be produced.
 
-A common usage for the second case is when making outbound service
+Only one value will be consumed from the returned channel, and the value must be a context map.
+
+A common usage for the asychronicity is when making outbound service
 requests. Use a `go` block as the return value, and Pedestal will
 expect an asynchronous response.
 
@@ -153,6 +171,13 @@ expect an asynchronous response.
 [IMPORTANT]
 .*Chaining With Async Interceptors*
 Any interceptor downstream of an asynchronous interceptor will be executed in the `core.async` thread pool.
+This can be problematic if any later interceptor or handler performs any blocking I/O.  Generally speaking,
+if any interceptor is asynchronous, all following non-trivial interceptors should also be asynchronous.
+
+When an interceptor returns a channel, the request processing thread can be returned to the servlet container.
+This may allow another pending request to be processed while the initial request is parked, waiting for
+a response from the authentication system.
+
 
 === IntoInterceptor
 
@@ -180,7 +205,7 @@ represents anything that can be used as an interceptor. Pedestal extends that pr
 | The symbol is resolved and its target is used as an interceptor.
 
 | Var
-| The var is dereferenced and its value is used as an interceptor.
+| The var is de-referenced and its value is used as an interceptor.
 
 |===
 
@@ -211,7 +236,7 @@ if processing should not continue.
 .*Interceptor Records*
 
 --
-Interceptors that are explicitely enqueued by the application must
+Interceptors that are explicitly enqueued by the application must
 be defined using the `io.pedestal.interceptor/interceptor`
 function. This function takes a value which extends `IntoInterceptor`
 and returns an `Interceptor` Record.
@@ -239,3 +264,21 @@ position of a stack.
 
 Pedestal supports defining interceptor-specific error handlers via the
 `:error` key. Refer to the link:error-handling[Error Handling] reference for more details.
+
+=== Stock Interceptors
+
+The link:../api/pedestal.service/index.html[`pedestal-service`] library includes a large set of interceptors
+that are specialized for HTTP request handling.
+
+See the following namespaces for stock interceptors:
+
+- link:../api/pedestal.service/io.pedestal.http.body-params.html[`io.pedestal.http.body-params`]
+- link:../api/pedestal.service/io.pedestal.http.content-negotiation.html[`io.pedestal.http.content-negotiation`]
+- link:../api/pedestal.service/io.pedestal.http.cors.html[`io.pedestal.http.cors`]
+- link:../api/pedestal.service/io.pedestal.http.csrf.html[`io.pedestal.http.csrf`]
+- link:../api/pedestal.service/io.pedestal.http.ring-middlewares.html[`io.pedestal.http.ring-middlewares`]
+
+See the following namespaces for routing interceptors:
+
+- link:../api/pedestal.route/io.pedestal.http.route.html[`io.pedestal.http.route`]
+- link:../api/pedestal.route/io.pedestal.http.route.router.html[`io.pedestal.http.route.router`]

--- a/content/reference/src/org/example/middleware.clj
+++ b/content/reference/src/org/example/middleware.clj
@@ -1,0 +1,10 @@
+(ns org.example.middleware)
+
+(defn wrap-head-unsupported
+  [handler]
+  (fn [request]                                             ;; <1>
+    (if (= :head (:request-method request))                 ;; <2>
+      {:status 400                                          ;; <3>
+       :headers {}
+       :body "HEAD not supported"}
+      (handler request))))                                  ;; <4>


### PR DESCRIPTION
This moves some of the interceptor content to the interceptor reference page, and explains and justifies interceptors in terms of Ring.